### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
@@ -10,15 +10,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -33,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
     },
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^11.0|^12.0",
-        "illuminate/http": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0",
-        "illuminate/view": "^11.0|^12.0"
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/http": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/view": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "exolnet/phpcs-config": "^2.0",
         "laravel/pint": "^1.1",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.10",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {


### PR DESCRIPTION
Ref #58942

This pull request updates the project to support Laravel 13 and PHPUnit 12, expanding compatibility and improving the CI test matrix. The most significant changes are in the GitHub Actions workflow and the `composer.json` dependencies.

**CI/CD and Dependency Updates:**

* Added Laravel 13 and PHPUnit 12 to the supported versions in `composer.json` for both runtime and development dependencies, and updated `orchestra/testbench` for compatibility.
* Expanded the GitHub Actions test matrix in `.github/workflows/tests.yml` to include Laravel 13 and PHPUnit 12, and added exclusions for incompatible combinations.
* Modified the workflow to explicitly require the correct version of PHPUnit in the install step, ensuring the right version is tested for each matrix combination.

**Workflow Improvements:**

* Enabled manual triggering of the test workflow by adding `workflow_dispatch` to the workflow triggers.
* Updated the job name in the test matrix to include the PHPUnit version for clearer identification of each test run.